### PR TITLE
Update to 0.11

### DIFF
--- a/src/huffman.zig
+++ b/src/huffman.zig
@@ -90,8 +90,7 @@ pub fn huffman_decoder_init(d: *huffman_decoder_t, lengths: [*]const u8, n: usiz
         assert(d.sentinel_bits[l] >= code[l]); // "No overflow!"
 
         sym_idx[l] = sym_idx[l - 1] + count[l - 1];
-        var sub_tmp: u16 = 0;
-        _ = @subWithOverflow(u16, sym_idx[l], code[l], &sub_tmp);
+        var sub_tmp: u16 = @subWithOverflow(sym_idx[l], code[l])[0];
         d.offset_first_sym_idx[l] = sub_tmp;
     }
 
@@ -119,7 +118,7 @@ pub fn huffman_decoder_init(d: *huffman_decoder_t, lengths: [*]const u8, n: usiz
 // Returns the decoded symbol number or -1 if no symbol could be decoded.
 // *num_used_bits will be set to the number of bits used to decode the symbol,
 // or zero if no symbol could be decoded.
-pub inline fn huffman_decode(d: *const huffman_decoder_t, bits: u16, num_used_bits: *usize) !u16 {
+pub inline fn huffman_decode(d: *const huffman_decoder_t, bits: u16, num_used_bits: *usize) Error!u16 {
     var lookup_bits: u64 = 0;
     var l: u5 = 0;
     var sym_idx: usize = 0;

--- a/src/hwzip.zig
+++ b/src/hwzip.zig
@@ -31,7 +31,7 @@ fn crc32(data: [*]const u8, size: usize) u32 {
 fn read_file(filename: [*:0]const u8, file_sz: *usize) ![]u8 {
     const file = try std.fs.cwd().openFile(
         filename[0..mem.indexOfSentinel(u8, 0x0, filename)],
-        .{ .read = true },
+        .{ .mode = .read_only },
     );
     defer file.close();
 

--- a/src/lz77.zig
+++ b/src/lz77.zig
@@ -192,8 +192,7 @@ pub fn hash4(ptr: [*]const u8) u32 {
     const HASH_MUL: u32 = 2654435761;
 
     // Knuth's multiplicative hash.
-    var mult: u32 = undefined;
-    _ = @mulWithOverflow(u32, bits.read32le(ptr), HASH_MUL, &mult);
+    var mult: u32 = @mulWithOverflow(bits.read32le(ptr), HASH_MUL)[0];
     return mult >> (32 - HASH_SIZE);
 }
 

--- a/src/shrink.zig
+++ b/src/shrink.zig
@@ -54,8 +54,7 @@ fn hash(code: u16, byte: u8) u32 {
     };
 
     // Knuth's multiplicative hash.
-    var mult: u32 = undefined;
-    _ = @mulWithOverflow(u32, (@intCast(u32, byte) << 16) | code, Static.HASH_MUL, &mult);
+    var mult: u32 = @mulWithOverflow((@intCast(u32, byte) << 16) | code, Static.HASH_MUL)[0];
     return (mult) >> (32 - HASH_BITS);
 }
 

--- a/src/zip.zig
+++ b/src/zip.zig
@@ -647,7 +647,7 @@ pub fn zip_write(
     mtimes: ?[*]const time.time_t,
     comment: ?[*:0]const u8,
     method: method_t,
-    callback: ?fn (filename: [*:0]const u8, method: method_t, size: u32, comp_size: u32) CallbackError!void,
+    comptime callback: ?fn (filename: [*:0]const u8, method: method_t, size: u32, comp_size: u32) CallbackError!void,
 ) !u32 {
     var i: u16 = 0;
     var p: [*]u8 = undefined;


### PR DESCRIPTION
Changes to make build in Zig 0.11

- new read_only syntax
- overflow builtins now return a tuple of result and overflow flag
- compiler required comptime